### PR TITLE
google/update-image/arch-linux: update the method of enabling AppArmor on Arch

### DIFF
--- a/tasks/google/update-image/arch-linux/task.yaml
+++ b/tasks/google/update-image/arch-linux/task.yaml
@@ -40,7 +40,7 @@ execute: |
         distro_install_package apparmor
         systemctl enable apparmor
 
-        sed -e 's/options /options apparmor=1 security=apparmor /g' -i /boot/loader/entries/arch.conf
+        sed -e 's/options /options lsm=landlock,lockdown,yama,integrity,apparmor,bpf/g' -i /boot/loader/entries/arch.conf
     fi
 
     # Clean disk before create the shapshot


### PR DESCRIPTION
Use `lsm=` kernel config option instead of deprecated security/apparmor.